### PR TITLE
minor tweaks

### DIFF
--- a/Benchmark/CodeToRun.R
+++ b/Benchmark/CodeToRun.R
@@ -37,4 +37,7 @@ runCodelistGeneratorBenchmark <- TRUE
 runCohortCharacteristicsBenchmark <- TRUE
 runDrugUtilisationBenchmark <- TRUE
 
+logSql<- FALSE
+logSqlExplain <- FALSE
+
 source("R/RunBenchmark.R")

--- a/Benchmark/R/RunBenchmark.R
+++ b/Benchmark/R/RunBenchmark.R
@@ -81,7 +81,3 @@ if (length(createdTables) > 0) {
     glue::glue()
   omopgenerics::logMessage(mes)
 }
-
-# Close connection
-omopgenerics::logMessage("closing connection")
-CDMConnector::cdmDisconnect(cdm)

--- a/Benchmark/R/RunBenchmark.R
+++ b/Benchmark/R/RunBenchmark.R
@@ -6,13 +6,14 @@ pkg_version <- "2.0.0"
 
 # create log file
 outputFolder <- here::here("Results")
-options(
-  omopgenerics.log_sql_path = paste0(outputFolder, "/sql_logs")
-  # ,
-  # omopgenerics.log_sql_explain_path = paste0(outputFolder, "/sql_explain")
-)
-log_file <- file.path(outputFolder, paste0("/log_", dbName, "_", format(Sys.time(), "%d_%m_%Y_%H_%M_%S"), ".txt"))
+if(isTRUE(logSql)){
+options(omopgenerics.log_sql_path = here::here("Results", "sql_logs"))
+}
+if(isTRUE(logSqlExplain)){
+options(omopgenerics.log_sql_explain_path = here::here("Results", "sql_explain"))
+}
 
+log_file <- file.path(outputFolder, paste0("/log_", dbName, "_", format(Sys.time(), "%d_%m_%Y_%H_%M_%S"), ".txt"))
 omopgenerics::createLogFile(logFile = log_file)
 
 omopgenerics::logMessage("reading tables in write schema (initial)")
@@ -65,7 +66,9 @@ omopgenerics::exportSummarisedResult(
   drugUtilisation_benchmark,
   minCellCount = minCellCount,
   path = outputFolder,
-  fileName = "result_benchmark_{cdm_name}_{date}.csv"
+  fileName = "result_benchmark_{cdm_name}_{date}.csv",
+  logSqlPath = NULL,
+  logExplainPath = NULL
 )
 
 # reading tables in write schema
@@ -82,29 +85,3 @@ if (length(createdTables) > 0) {
 # Close connection
 omopgenerics::logMessage("closing connection")
 CDMConnector::cdmDisconnect(cdm)
-
-# Zip the results
-omopgenerics::logMessage("ziping results")
-
-root_files <- list.files(
-  outputFolder,
-  pattern     = "\\.(csv|txt)$",
-  recursive   = FALSE,
-  full.names  = FALSE
-)
-
-
-# 2) All SQL files anywhere under outputFolder (keeps subfolder paths)
-sql_files <- list.files(
-  outputFolder,
-  pattern     = "\\.(sql|txt)$",
-  recursive   = TRUE,
-  full.names  = FALSE
-)
-
-# 3) Zip while preserving structure (paths like "sub/dir/file.sql" are kept)
-zip::zip(
-  zipfile = file.path(outputFolder, paste0("results_", dbName, ".zip")),
-  files   = c(root_files, sql_files),
-  root    = outputFolder
-)

--- a/Benchmark/R/functions.R
+++ b/Benchmark/R/functions.R
@@ -521,6 +521,8 @@ omopConstructorBenchmark <- function(cdm, iterations) {
   res <- res |>
     omopgenerics::newSummarisedResult(settings = settings)
 
+  omopgenerics::dropSourceTable(cdm = cdm, "observation_period")
+
   return(res)
 }
 

--- a/Benchmark/R/functions.R
+++ b/Benchmark/R/functions.R
@@ -596,8 +596,7 @@ safe_run <- function(expr, task_name = "task") {
       if (!inherits(tb, "try-error") && length(tb) > 0) {
         omopgenerics::logMessage(paste0("TRACEBACK for ", task_name, ":\n", paste(tb, collapse = "\n")))
       }
-
-
+      return(omopgenerics::emptySummarisedResult())
     }
   )
 }

--- a/Benchmark/renv.lock
+++ b/Benchmark/renv.lock
@@ -1329,12 +1329,13 @@
     "omopgenerics": {
       "Package": "omopgenerics",
       "Version": "1.3.2",
-      "Source": "Repository",
+      "Source": "GitHub",
       "Title": "Methods and Classes for the OMOP Common Data Model",
       "Authors@R": "c( person( \"Martí\", \"Català\", email = \"marti.catalasabate@ndorms.ox.ac.uk\",  role = c(\"aut\", \"cre\"), comment = c(ORCID = \"0000-0003-3308-9905\") ), person( \"Edward\", \"Burn\", email = \"edward.burn@ndorms.ox.ac.uk\", role = c(\"aut\"), comment = c(ORCID = \"0000-0002-9286-1128\") ), person( \"Mike\", \"Du\", email = \"mike.du@ndorms.ox.ac.uk\", role = c(\"ctb\"),  comment = c(ORCID = \"0000-0002-9517-8834\") ), person( \"Yuchen\", \"Guo\", email = \"yuchen.guo@ndorms.ox.ac.uk\", role = c(\"ctb\"), comment = c(ORCID = \"0000-0002-0847-4855\") ), person( \"Adam\", \"Black\", email = \"black@ohdsi.org\", role = c(\"ctb\"), comment = c(ORCID = \"0000-0001-5576-8701\") ), person( \"Marta\", \"Alcalde-Herraiz\",  email = \"marta.alcaldeherraiz@ndorms.ox.ac.uk\", role = c(\"ctb\"),  comment = c(ORCID = \"0009-0002-4405-1814\") ) )",
       "Description": "Provides definitions of core classes and methods used by analytic  pipelines that query the OMOP (Observational Medical Outcomes Partnership)  common data model.",
       "License": "Apache License (>= 2)",
       "Encoding": "UTF-8",
+      "Roxygen": "list(markdown = TRUE)",
       "RoxygenNote": "7.3.2",
       "Imports": [
         "cli",
@@ -1375,10 +1376,15 @@
       "Config/testthat/edition": "3",
       "Config/testthat/parallel": "true",
       "VignetteBuilder": "knitr",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "omopgenerics",
+      "RemoteUsername": "darwin-eu",
+      "RemoteRef": "test_utf8",
+      "RemoteSha": "f8700e1fc381d07dc898106c02babee926f523d9",
       "NeedsCompilation": "no",
       "Author": "Martí Català [aut, cre] (ORCID: <https://orcid.org/0000-0003-3308-9905>), Edward Burn [aut] (ORCID: <https://orcid.org/0000-0002-9286-1128>), Mike Du [ctb] (ORCID: <https://orcid.org/0000-0002-9517-8834>), Yuchen Guo [ctb] (ORCID: <https://orcid.org/0000-0002-0847-4855>), Adam Black [ctb] (ORCID: <https://orcid.org/0000-0001-5576-8701>), Marta Alcalde-Herraiz [ctb] (ORCID: <https://orcid.org/0009-0002-4405-1814>)",
-      "Maintainer": "Martí Català <marti.catalasabate@ndorms.ox.ac.uk>",
-      "Repository": "CRAN"
+      "Maintainer": "Martí Català <marti.catalasabate@ndorms.ox.ac.uk>"
     },
     "pillar": {
       "Package": "pillar",

--- a/Benchmark/renv.lock
+++ b/Benchmark/renv.lock
@@ -2268,34 +2268,6 @@
       "Author": "Jim Hester [aut], Lionel Henry [aut, cre], Kirill Müller [aut], Kevin Ushey [aut], Hadley Wickham [aut], Winston Chang [aut], Jennifer Bryan [ctb], Richard Cotton [ctb], Posit Software, PBC [cph, fnd]",
       "Maintainer": "Lionel Henry <lionel@posit.co>",
       "Repository": "CRAN"
-    },
-    "zip": {
-      "Package": "zip",
-      "Version": "2.3.3",
-      "Source": "Repository",
-      "Title": "Cross-Platform 'zip' Compression",
-      "Authors@R": "c( person(\"Gábor\", \"Csárdi\", , \"csardi.gabor@gmail.com\", role = c(\"aut\", \"cre\")), person(\"Kuba\", \"Podgórski\", role = \"ctb\"), person(\"Rich\", \"Geldreich\", role = \"ctb\"), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"), comment = c(ROR = \"03wc8by49\")) )",
-      "Description": "Cross-Platform 'zip' Compression Library. A replacement for the 'zip' function, that does not require any additional external tools on any platform.",
-      "License": "MIT + file LICENSE",
-      "URL": "https://github.com/r-lib/zip, https://r-lib.github.io/zip/",
-      "BugReports": "https://github.com/r-lib/zip/issues",
-      "Suggests": [
-        "covr",
-        "pillar",
-        "processx",
-        "R6",
-        "testthat",
-        "withr"
-      ],
-      "Config/Needs/website": "tidyverse/tidytemplate",
-      "Config/testthat/edition": "3",
-      "Config/usethis/last-upkeep": "2025-05-07",
-      "Encoding": "UTF-8",
-      "RoxygenNote": "7.3.2.9000",
-      "NeedsCompilation": "yes",
-      "Author": "Gábor Csárdi [aut, cre], Kuba Podgórski [ctb], Rich Geldreich [ctb], Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
-      "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-      "Repository": "RSPM"
     }
   }
 }


### PR DESCRIPTION
don't include sql in results file and only record sql if data partner chooses to

if error, return empty summarised result (so export works)

return single csv as result to share (no  zip)

drop obs table created by omopConstructor

leave connection open at end

use omogenerics utf8 branch for #33 